### PR TITLE
Ignore files that only contain sum types when reporting code coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
         run: go mod download
 
       - name: Run tests
-        run: go test ./... -coverprofile=coverage.txt
+        run: go test ./... -coverprofile=coverage.out
 
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v5

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,3 @@
+ignore:
+  - "internal/parser/ast.go"
+  - "internal/parser/token.go"


### PR DESCRIPTION
The methods in token.go and ast.go are only there to encode variant types in Go's type system.  We never actually call them so they should be excluded from the code coverage numbers.